### PR TITLE
Use scope service to resolve the list of ISecurityTokenValidator

### DIFF
--- a/src/MakingSense.AspNetCore.Authentication.SimpleToken/SimpleTokenAuthenticationExtensions.cs
+++ b/src/MakingSense.AspNetCore.Authentication.SimpleToken/SimpleTokenAuthenticationExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.IdentityModel.Tokens;
 using System;
@@ -32,17 +33,9 @@ namespace MakingSense.AspNetCore.Authentication.SimpleToken
 					{
 						options.SecurityTokenValidatorsFactory = () =>
 						{
-							// TODO: fix it because it is using app services, and it should use scope services,
-							// a work around could be:
-							// ```
-							// SecurityTokenValidatorsFactory = () =>
-							// {
-							//     var context = builder.Services.BuildServiceProvider().GetService<IHttpContextAccessor>().HttpContext;
-							//     return context.RequestServices.GetServices<ISecurityTokenValidator>();
-							// }
-							// ```
 							var serviceProvider = builder.Services.BuildServiceProvider();
-							return serviceProvider.GetServices<ISecurityTokenValidator>();
+							var httpContext = serviceProvider.GetService<IHttpContextAccessor>().HttpContext;
+							return httpContext.RequestServices.GetServices<ISecurityTokenValidator>();
 						};
 					}
 				});


### PR DESCRIPTION
Use scope service to resolve the list of ISecurityTokenValidator to generate the SecurityToeknValidatorFactory if not set in the Startup of the application.

This change, prevent a memory leak avoiding create more than twenty 'IServiceProvider' instances for internal use of Entity Framework